### PR TITLE
Add per WriterBackend instance telemetry

### DIFF
--- a/src/NATS.cc
+++ b/src/NATS.cc
@@ -6,13 +6,39 @@
 
 #include "zeek/ID.h"
 #include "zeek/Val.h"
+#include "zeek/logging/WriterFrontend.h"
+#include "zeek/telemetry/Manager.h"
 
 #include "Plugin.h"
 
 using namespace zeek::logging;
 using namespace zeek::plugin::Zeek_Log_Writer_NATS::detail;
 
-NATSWriter::NATSWriter(WriterFrontend* frontend) : WriterBackend(frontend) {}
+NATSWriter::NATSWriter(WriterFrontend* frontend) : WriterBackend(frontend) {
+    // Initialize the NATS metrics with callbacks that use
+    // the embedded WriterStats in in a NATSWriter instance.
+    std::vector<telemetry::LabelView> labels = {{"filter-name", frontend->GetFilterName()},
+                                                {"path", frontend->Info().path}};
+
+    dropped_writes_total = zeek::telemetry_mgr->CounterInstance(
+        "zeek", "nats-log-writer-backend-dropped-writes", labels,
+        "Dropped log writes of the NATS log writer because of connectivity issues or other problems.", "",
+        [stats = &writer_stats]() { return static_cast<double>(stats->dropped_writes); }),
+
+    publish_errors_total =
+        zeek::telemetry_mgr
+            ->CounterInstance("zeek", "nats-log-writer-backend-publish-errors", labels,
+                              "Publish errors reported from the NATS server via the installed AckHandler", "",
+                              [stats = &writer_stats]() { return static_cast<double>(stats->publish_errors); }),
+
+    publish_acks_total =
+        zeek::telemetry_mgr->CounterInstance("zeek", "nats-log-writer-backend-publish-acks", labels,
+                                             "Publish acknowledgements reported via the installed AckHandler", "",
+                                             [stats = &writer_stats]() {
+                                                 return static_cast<double>(stats->publish_acks);
+                                             });
+}
+
 NATSWriter::~NATSWriter() {
     debug("destructor");
     if ( opts )
@@ -23,6 +49,12 @@ NATSWriter::~NATSWriter() {
 
     if ( js )
         jsCtx_Destroy(js);
+
+    // The counter instances outlive the NATSWriter, but the callbacks
+    // point at the embedded writer_stats, so ensure to remove them.
+    dropped_writes_total->RemoveCallback();
+    publish_acks_total->RemoveCallback();
+    publish_errors_total->RemoveCallback();
 }
 
 namespace {

--- a/src/NATS.cc
+++ b/src/NATS.cc
@@ -1,5 +1,6 @@
 #include "NATS.h"
 
+#include <nats/nats.h>
 #include <cstdio>
 #include <mutex>
 
@@ -25,9 +26,17 @@ NATSWriter::~NATSWriter() {
 }
 
 namespace {
-void _jsPubErr(jsCtx* js, jsPubAckErr* pae, void* closure) {
+void _jsPubAck(jsCtx* js, natsMsg* msg, jsPubAck* pa, jsPubAckErr* pae, void* closure) {
     auto* writer = static_cast<NATSWriter*>(closure);
-    writer->PublishError(pae->ErrCode, pae->ErrText);
+
+    if ( pa != nullptr ) {
+        writer->PublishAck(pa->Stream, pa->Sequence, pa->Domain, pa->Duplicate);
+    }
+    else if ( pae != nullptr ) {
+        writer->PublishError(pae->ErrCode, pae->ErrText);
+    }
+
+    natsMsg_Destroy(msg);
 }
 
 struct Replace {
@@ -47,6 +56,10 @@ std::string template_replace(std::string tmpl, std::vector<Replace>& replacement
     return tmpl;
 }
 } // namespace
+
+void NATSWriter::PublishAck(const char* stream, uint64_t sequence, const char* domain, bool duplicate) {
+    ++writer_stats.publish_acks;
+}
 
 void NATSWriter::PublishError(int code, const char* text) {
     // May be called asynchronously and from DoWrite(), so don't use
@@ -142,8 +155,8 @@ bool NATSWriter::DoInit(const WriterInfo& info, int arg_num_fields, const thread
     }
 
     jsOpts.PublishAsync.MaxPending = publish_async_max_pending;
-    jsOpts.PublishAsync.ErrHandler = _jsPubErr;
-    jsOpts.PublishAsync.ErrHandlerClosure = this;
+    jsOpts.PublishAsync.AckHandler = _jsPubAck;
+    jsOpts.PublishAsync.AckHandlerClosure = this;
     jsOpts.PublishAsync.StallWait = publish_async_stall_wait_ms;
 
     return true;
@@ -200,6 +213,7 @@ bool NATSWriter::Connect() {
 
     return conn;
 }
+
 bool NATSWriter::DoWrite(int num_fields, const threading::Field* const* fields, threading::Value** vals) {
     natsStatus s = NATS_OK;
     jsErrCode jerr;

--- a/src/NATS.h
+++ b/src/NATS.h
@@ -13,8 +13,9 @@ using namespace zeek::logging;
 namespace zeek::plugin::Zeek_Log_Writer_NATS::detail {
 
 struct NATSWriterStats {
-    zeek_uint_t dropped_writes = 0;
-    zeek_uint_t publish_errors = 0;
+    std::atomic<zeek_uint_t> dropped_writes = 0;
+    std::atomic<zeek_uint_t> publish_errors = 0;
+    std::atomic<zeek_uint_t> publish_acks = 0;
 };
 
 class NATSWriter : public WriterBackend {
@@ -24,6 +25,10 @@ public:
 
     static WriterBackend* Instantiate(WriterFrontend* frontend) { return new NATSWriter(frontend); }
 
+    // Callback for message acknowledgements.
+    void PublishAck(const char* stream, uint64_t sequence, const char* domain, bool duplicate);
+
+    // Callback for message delivery errors.
     void PublishError(int code, const char* text);
 
 protected:

--- a/src/NATS.h
+++ b/src/NATS.h
@@ -6,6 +6,7 @@
 
 #include "zeek/Desc.h"
 #include "zeek/logging/WriterBackend.h"
+#include "zeek/telemetry/Counter.h"
 #include "zeek/threading/formatters/JSON.h"
 
 using namespace zeek::logging;
@@ -69,5 +70,9 @@ private:
     int64_t publish_async_max_pending;
     int64_t publish_async_stall_wait_ms;
     int64_t publish_async_complete_max_wait_ms;
+
+    zeek::telemetry::CounterPtr dropped_writes_total;
+    zeek::telemetry::CounterPtr publish_errors_total;
+    zeek::telemetry::CounterPtr publish_acks_total;
 };
 } // namespace zeek::plugin::Zeek_Log_Writer_NATS::detail


### PR DESCRIPTION
Metrics look something like this:
```
$ curl -s localhost:9991/metrics | grep zeek_nats
# HELP zeek_nats_log_writer_backend_dropped_writes_total Dropped log writes of the NATS log writer because of connectivity issues or other problems.
# TYPE zeek_nats_log_writer_backend_dropped_writes_total counter
zeek_nats_log_writer_backend_dropped_writes_total{filter_name="default",path="dns"} 0
zeek_nats_log_writer_backend_dropped_writes_total{filter_name="default",path="conn"} 0
zeek_nats_log_writer_backend_dropped_writes_total{filter_name="default",path="analyzer"} 0
zeek_nats_log_writer_backend_dropped_writes_total{filter_name="default",path="http"} 0
zeek_nats_log_writer_backend_dropped_writes_total{filter_name="default",path="weird"} 0
zeek_nats_log_writer_backend_dropped_writes_total{filter_name="default",path="packet_filter"} 0
# HELP zeek_nats_log_writer_backend_publish_errors_total Publish errors reported from the NATS server via the installed AckHandler
# TYPE zeek_nats_log_writer_backend_publish_errors_total counter
zeek_nats_log_writer_backend_publish_errors_total{filter_name="default",path="dns"} 0
zeek_nats_log_writer_backend_publish_errors_total{filter_name="default",path="conn"} 0
zeek_nats_log_writer_backend_publish_errors_total{filter_name="default",path="analyzer"} 0
zeek_nats_log_writer_backend_publish_errors_total{filter_name="default",path="http"} 0
zeek_nats_log_writer_backend_publish_errors_total{filter_name="default",path="weird"} 0
zeek_nats_log_writer_backend_publish_errors_total{filter_name="default",path="packet_filter"} 0
# HELP zeek_nats_log_writer_backend_publish_acks_total Publish acknowledgements reported via the installed AckHandler
# TYPE zeek_nats_log_writer_backend_publish_acks_total counter
zeek_nats_log_writer_backend_publish_acks_total{filter_name="default",path="dns"} 5
zeek_nats_log_writer_backend_publish_acks_total{filter_name="default",path="conn"} 17
zeek_nats_log_writer_backend_publish_acks_total{filter_name="default",path="analyzer"} 6
zeek_nats_log_writer_backend_publish_acks_total{filter_name="default",path="http"} 7
zeek_nats_log_writer_backend_publish_acks_total{filter_name="default",path="weird"} 13
zeek_nats_log_writer_backend_publish_acks_total{filter_name="default",path="packet_filter"} 1
```

@bwerthmann - is this roughly what you're looking for? As mentioned in DM, this is specific to the NATS log writer plugin. Don't want to put anything generic into the Zeek tree. This hasn't been requested by anyone else than you, so keeping it in the NATS plugin for now seems fine.